### PR TITLE
Updated cmdImg_node

### DIFF
--- a/cmdImg_node.cpp
+++ b/cmdImg_node.cpp
@@ -1,0 +1,257 @@
+#include <signal.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/poll.h>
+#include <sstream>
+#include <boost/thread/thread.hpp>
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+#include <fstream> // Required for file processing.
+#include <cassert> // Required to check if file exists.
+#include <iostream>
+#include <stdlib.h> // This is required for the system() call.
+#include <jaguar4x4_2014/GPSInfo.h> // This is required to process GPS data.
+#include <jaguar4x4_2014/IMUData.h> // This is required to process IMU data.
+#include <sys/stat.h> // This is required to verify the existence of certain files during processing.
+#include <chrono> // This is required for the timestamp on each command/image.
+#include <boost/function.hpp>
+
+
+// This all handles image processing. Will remove system() once properly implemented.
+// cv_bridge and opencv2 need to be installed manually. Working on that now.
+#include <cv_bridge/cv_bridge.h> // https://github.com/ros-perception/vision_opencv.git
+#include <opencv2/imgproc/imgproc.hpp> // https://docs.opencv.org/4.x/d7/d9f/tutorial_linux_install.html or https://www.geeksforgeeks.org/how-to-install-opencv-in-c-on-linux/ (MAKE SURE TO UPDATE DIRECTORY IN CMAKELISTS.TXT. WILL SAVE YOU A LOT OF TIME.)
+#include <opencv2/opencv.hpp>
+#include <sensor_msgs/image_encodings.h>
+#include <image_transport/image_transport.h> // https://github.com/ros-perception/image_common.git
+
+
+/* READ ME FIRST BEFORE OPERATING NODE
+For the system() methods to operate properly, assuming you're running on 
+Ubuntu 20.04 (which you should be for ROS1 Noetic to work properly), you need to reconfigure your shell, which is currently configured to 
+/bin/dash, to /bin/bash, as you will otherwise get a message such as this: 
+
+"sh: 1: source: not found"
+
+As well as all the system() methods not functioning.
+
+To fix this, open up a new terminal window and enter in:
+
+"sudo dpkg-reconfigure dash"
+
+Enter in your password as normal.
+
+This will then ask whether you want dash to be your default system shell; 
+select "No", and then bash will be configured as your shell (or, /bin/sh
+will be pointing to /bin/bash).
+*/
+
+class cmdImgSync{
+
+public:
+	cmdImgSync() : ih(nh){
+	
+		motor_cmd_sub_ = nh.subscribe<std_msgs::String>("drrobot_motor_cmd", 1, boost::bind(&cmdImgSync::jagCmnd_cb, this, _1));
+		
+		gpsData = nh.subscribe<jaguar4x4_2014::GPSInfo>("drrobot_gps", 1, boost::bind(&cmdImgSync::gps_cb, this, _1));
+		
+		imuData = nh.subscribe<jaguar4x4_2014::IMUData>("drrobot_imu", 1, boost::bind(&cmdImgSync::imu_cb, this, _1));
+		
+		imgData = ih.subscribe("axis/image_raw", 1, boost::bind(&cmdImgSync::img_cb, this, _1));
+	}
+	
+	~cmdImgSync(){}
+	
+	void jagCmnd_cb(const std_msgs::String::ConstPtr& cmnd);
+	void gps_cb(const jaguar4x4_2014::GPSInfo::ConstPtr& gpsInfo);
+	void imu_cb(const jaguar4x4_2014::IMUData::ConstPtr& imuInfo);
+	void img_cb(const sensor_msgs::ImageConstPtr& img);
+	
+	void updateData();
+
+	std::string timeConverter(std::chrono::milliseconds timeSinceEpoch);
+	bool pubReady();
+	
+	
+private:
+	ros::NodeHandle nh;
+	image_transport::ImageTransport ih;
+	ros::Subscriber motor_cmd_sub_; // Same name as in drrobot_player.cpp for clarity
+	ros::Subscriber gpsData;
+	ros::Subscriber imuData;
+	image_transport::Subscriber imgData;
+	
+	double latiData;
+	double longiData;
+	double yawData;
+
+	std::string curCmnd = "N/A";
+	bool cmndUpdated = false;
+	std::string curTime;
+
+	int counter = 0;
+	
+	std::fstream jaguarRecord;
+	std::fstream commandRecord;
+	std::fstream commandImage;
+	
+	std::chrono::milliseconds tse;
+	int msEpoch;
+	int secEpoch;
+	int minEpoch;
+	int hrEpoch;
+};
+
+// ------------------------------------------------------------
+
+void cmdImgSync::jagCmnd_cb(const std_msgs::String::ConstPtr& cmnd){
+	curCmnd = cmnd->data;
+	cmndUpdated = true;
+}
+
+void cmdImgSync::gps_cb(const jaguar4x4_2014::GPSInfo::ConstPtr& gpsInfo){
+	latiData = gpsInfo->latitude;
+	longiData = gpsInfo->longitude;
+}
+
+void cmdImgSync::imu_cb(const jaguar4x4_2014::IMUData::ConstPtr& imuInfo){
+	yawData = imuInfo->yaw;
+}
+
+void cmdImgSync::img_cb(const sensor_msgs::ImageConstPtr& img){
+	commandImage.open("/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/commandImage.dat", std::ios::app);
+	
+	assert(commandImage);
+	
+	tse = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
+	curTime = this->timeConverter(tse);
+	
+	std::string fileDest = "/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/" + curTime + ".png";
+		
+	// Converting a sensor_msgs::Image message into a CVImage
+	cv_bridge::CvImagePtr cv_image;
+	
+	cv_image = cv_bridge::toCvCopy(img);
+	
+	cv::imwrite(fileDest, cv_image->image);
+	
+	commandImage << fileDest << ", " << curCmnd << std::endl;
+	
+	commandImage.close();
+}
+
+bool cmdImgSync::pubReady(){
+	bool motorWork = false;
+	bool gpsWork = false;
+	bool imuWork = false;
+	bool imgWork = false;
+	
+	if (motor_cmd_sub_.getNumPublishers() < 1){
+		//std::cout << "/drrobot_motor_cmd not responding.\n";
+		//return false;
+	} else { motorWork = true; /* return true;*/ }
+	
+	if (gpsData.getNumPublishers() < 1){
+		//std::cout << "/drrobot_gps not responding.\n";
+		//return false;
+	} else { gpsWork = true; /* return true;*/ }
+	
+	if (imuData.getNumPublishers() < 1){
+		//std::cout << "/drrobot_imu not responding.\n";
+		//return false;
+	} else { imuWork = true; /* return true;*/ }
+	
+	if (imgData.getNumPublishers() < 1){
+		//std::cout << "/axis/image_raw not responding.\n";
+		//return false;
+	} else { imgWork = true; /* return true;*/ }
+	
+	if (motorWork && gpsWork && imuWork && imgWork){
+		return true;
+	} else { return false; }
+}
+
+std::string cmdImgSync::timeConverter(std::chrono::milliseconds timeSinceEpoch){	
+    	int msEpoch = timeSinceEpoch.count() % 1000;
+    	int secEpoch = (timeSinceEpoch.count() / 1000) % 60;
+    	int minEpoch = (timeSinceEpoch.count() / 60000 ) % 60;
+    	int hrEpoch = (timeSinceEpoch.count() / 86400000) % 24;
+    	
+    	std::string timestamp = std::to_string(hrEpoch) + ":" + std::to_string(minEpoch) + ":" + std::to_string(secEpoch) + ":" + std::to_string(msEpoch);
+    	
+	return timestamp;
+}
+
+void cmdImgSync::updateData(){
+	jaguarRecord.open("/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/jaguarRecordCopy.dat", std::ios::app);
+	commandRecord.open("/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/commandRecord.dat", std::ios::app);
+
+	assert(jaguarRecord);
+	assert(commandRecord);
+	
+	tse = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now().time_since_epoch());
+	curTime = this->timeConverter(tse);
+
+	if (cmndUpdated){
+		jaguarRecord << curCmnd << ", ";
+		commandRecord << curTime << ", " << counter << "|" << curCmnd << std::endl;
+		cmndUpdated = false;
+	} else {
+		jaguarRecord << "No current command, ";
+		commandRecord << curTime << ", " << counter << "|" << "NO_CHANGE" << std::endl;
+	}
+
+	jaguarRecord << std::fixed << std::setprecision(13); // This is set to 13 decimal points of precision, after the decimal point, to keep the GPS data accurate.
+	jaguarRecord << yawData << ", " << latiData << ", " << longiData << ", "; 
+	jaguarRecord << 0 << std::endl; // This line is simply for the altitude, which the robot does not record, but is required for the GUI program.
+
+	// This takes a photo and saves it to the default saving location. This is still a bit buggy. Working on some fixes at the moment.
+	// std::system("source /opt/ros/noetic/setup.bash && source ~/.bashrc && cd ~/catkin_rbt_ws/ && source devel/setup.bash && rosservice call /image_saver/save");
+	// std::system("rosservice call /image_saver/save"); // Going to see if this improves performance over the first system() call above down in main().
+	counter++;
+	
+	jaguarRecord.close();
+	commandRecord.close();
+}
+
+// ------------------------------------------------------------
+
+int main(int argc, char** argv){
+	// Initializing the node.
+	ros::init(argc,argv,"cmdImg_node", ros::init_options::AnonymousName | ros::init_options::NoSigintHandler);
+
+	// Using threads as a temporary fix to the performance issues until an alternative to std::thread can be found.
+	cmdImgSync syncer;
+	boost::thread t1;
+	boost::thread t2;
+
+	std::system("gnome-terminal -- sh -c \"source /opt/ros/noetic/setup.bash && source ~/.bashrc && cd ~/catkin_rbt_ws/ && source devel/setup.bash && roslaunch axis_camera axis.launch hostname:=192.168.0.65:8081 username:=root password:=drrobot encrypted:=true\"");
+	std::system("gnome-terminal -- sh -c \"echo 'Do NOT close this terminal. It republishes the compressed images from /axis/image_raw/compressed to /axis/image_raw and decompresses them in the process.' && rosrun image_transport republish compressed in:=/axis/image_raw raw out:=/axis/image_raw\"");
+	//std::system("gnome-terminal -- sh -c \"source /opt/ros/noetic/setup.bash && source ~/.bashrc && cd ~/catkin_rbt_ws/ && source devel/setup.bash && rosrun image_view image_saver image:=/axis/image_raw _image_transport:=compressed _filename_format:=FRAME%04i.jpg _save_all_image:=false __name:=image_saver\"");
+	
+	// Loop until the jaguar4x4_2014_node node responds
+	while(!syncer.pubReady()){
+		//std::cout << "Not ready.\n";
+	}
+	
+	ros::Rate loopRate(50);
+	
+	while(syncer.pubReady()){
+		//std::cout << "Running...\n";
+		t1 = boost::thread(boost::bind(&cmdImgSync::updateData, &syncer));
+		t1.join();
+		
+		//t2 = boost::thread(boost::bind(std::system, "source /opt/ros/noetic/setup.bash && source ~/.bashrc && cd ~/catkin_rbt_ws/ && source devel/setup.bash && rosservice call /image_saver/save"));
+		
+		// Spinning the node once
+		ros::spinOnce();
+		loopRate.sleep();
+
+		//t2.join();
+	}
+	
+	std::cout << "Stopped running.\n";
+	
+	return(0); // Confirming successful program execution. 
+}

--- a/commandImage.dat
+++ b/commandImage.dat
@@ -1,0 +1,662 @@
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:759.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:859.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:959.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:16:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:59.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:159.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:239.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:259.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:299.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:339.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:359.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:399.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:439.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:459.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:499.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:539.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:559.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:599.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:639.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:659.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:699.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:739.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:759.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:859.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:959.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:17:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:79.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:159.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:239.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:259.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:299.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:339.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:359.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:399.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:439.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:459.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:499.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:539.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:559.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:599.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:639.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:679.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:699.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:739.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:759.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:859.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:18:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:59.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:159.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:239.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:259.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:299.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:339.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:359.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:399.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:439.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:479.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:499.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:539.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:579.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:599.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:639.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:659.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:699.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:739.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:759.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:859.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:959.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:19:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:59.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:159.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:239.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:259.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:299.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:339.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:359.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:399.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:439.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:459.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:499.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:539.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:579.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:599.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:639.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:679.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:699.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:739.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:779.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:879.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:979.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:20:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:79.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:179.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:239.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:279.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:299.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:339.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:379.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:399.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:439.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:479.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:499.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:539.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:579.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:599.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:639.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:679.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:699.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:739.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:779.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:879.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:979.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:21:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:79.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:179.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:239.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:279.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:299.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:339.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:379.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:399.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:439.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:479.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:499.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:539.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:579.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:599.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:639.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:679.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:699.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:739.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:779.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:799.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:839.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:879.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:899.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:939.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:979.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:22:999.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:39.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:79.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:99.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:139.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:179.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:199.png, N/A
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:239.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:279.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:299.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:339.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:379.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:399.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:439.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:479.png, MMW !MG
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:499.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:539.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:839.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:879.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:899.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:939.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:979.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:23:999.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:39.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:79.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:99.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:139.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:179.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:199.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:239.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:299.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:339.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:399.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:439.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:499.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:539.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:699.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:739.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:839.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:899.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:939.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:24:999.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:39.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:79.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:99.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:139.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:179.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:199.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:239.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:279.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:299.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:339.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:379.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:399.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:439.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:479.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:499.png, MMW !M 200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:539.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:699.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:739.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:839.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:899.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:939.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:979.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:25:999.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:39.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:79.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:119.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:139.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:179.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:219.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:239.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:299.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:339.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:399.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:439.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:539.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:739.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:839.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:26:999.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:99.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:139.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:179.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:219.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:239.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:279.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:319.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:359.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:379.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:439.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:539.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:739.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:839.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:879.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:919.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:939.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:27:979.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:19.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:39.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:79.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:139.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:179.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:239.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:339.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:439.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:539.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:719.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:759.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:799.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:839.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:28:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:39.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:339.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:439.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:739.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:839.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:29:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:39.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:199.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:239.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:399.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:419.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:439.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:479.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:599.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:619.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:639.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:30:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:39.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:79.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:139.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:179.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:239.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:339.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:439.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:519.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:539.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:579.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:619.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:659.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:679.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:719.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:739.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:839.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:31:979.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:19.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:59.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:79.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:119.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:159.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:179.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:219.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:259.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:379.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:419.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:459.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:479.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:519.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:559.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:579.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:619.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:32:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:79.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:119.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:159.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:179.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:219.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:259.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:279.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:319.png, MMW !M 200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:659.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:679.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:719.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:759.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:779.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:819.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:859.png, MMW !M -200 -200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:33:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:19.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:59.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:79.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:119.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:159.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:179.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:219.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:259.png, MMW !M -200 200
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:34:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:79.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:159.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:179.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:259.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:779.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:35:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:79.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:159.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:179.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:259.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:279.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:379.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:479.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:579.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:679.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:879.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:36:979.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:79.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:159.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:199.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:259.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:299.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:399.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:499.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:699.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:899.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:37:999.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:99.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:159.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:199.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:259.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:299.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:399.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:499.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:699.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:899.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:959.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:38:999.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:19.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:59.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:99.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:119.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:159.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:199.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:219.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:259.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:299.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:319.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:359.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:399.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:419.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:459.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:499.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:519.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:559.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:599.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:619.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:659.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:699.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:719.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:759.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:799.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:819.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:859.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:899.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:919.png, MMW !M 0 0
+/home/jackal/catkin_rbt_ws/src/jaguar4x4_ROS_2014/src/camera_images/11:56:39:959.png, MMW !M 0 0


### PR DESCRIPTION
Able to record at a stable and consistent 30 FPS; performance overhead has been fixed. Planning to remove most system() calls in the next update.